### PR TITLE
Replace hero gif with interactive network animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,9 @@
 
     <!-- Hero header (kept; only visual restyle) -->
     <header class="header">
+      <div class="hero-network" aria-hidden="true">
+        <canvas id="heroNetworkCanvas"></canvas>
+      </div>
       <div class="profile-frame">
         <img src="./media/profilepic.jpeg" alt="Profile Picture">
       </div>

--- a/scripts.js
+++ b/scripts.js
@@ -82,3 +82,158 @@
   track.addEventListener('mouseleave', start);
   document.addEventListener('visibilitychange', ()=> document.hidden ? stop() : start());
 })();
+
+/* Hero network animation */
+(function(){
+  const canvas = document.getElementById('heroNetworkCanvas');
+  const header = document.querySelector('.header');
+  if(!canvas || !header) return;
+  if(window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  const ctx = canvas.getContext('2d');
+  let width = 0;
+  let height = 0;
+  let dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let nodes = [];
+
+  const pointer = { x: 0, y: 0, active: false, last: 0 };
+
+  function updatePointer(evt){
+    const rect = canvas.getBoundingClientRect();
+    pointer.x = (evt.clientX || (evt.touches && evt.touches[0]?.clientX) || 0) - rect.left;
+    pointer.y = (evt.clientY || (evt.touches && evt.touches[0]?.clientY) || 0) - rect.top;
+    pointer.active = true;
+    pointer.last = performance.now();
+  }
+
+  function deactivatePointer(){
+    pointer.active = false;
+  }
+
+  header.addEventListener('pointermove', updatePointer, { passive: true });
+  header.addEventListener('pointerdown', updatePointer, { passive: true });
+  header.addEventListener('pointerleave', deactivatePointer);
+  header.addEventListener('touchmove', updatePointer, { passive: true });
+  header.addEventListener('touchend', deactivatePointer);
+
+  function resize(){
+    width = canvas.clientWidth;
+    height = canvas.clientHeight;
+    dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = Math.max(1, Math.floor(width * dpr));
+    canvas.height = Math.max(1, Math.floor(height * dpr));
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    buildNodes();
+  }
+
+  function buildNodes(){
+    const area = width * height;
+    const density = 0.00012;
+    const targetCount = Math.max(60, Math.min(180, Math.floor(area * density)));
+    nodes = new Array(targetCount).fill(null).map(()=>{
+      const depth = 0.3 + Math.random() * 0.7;
+      return {
+        x: Math.random() * width,
+        y: Math.random() * height,
+        vx: (Math.random() - 0.5) * 0.35 * depth,
+        vy: (Math.random() - 0.5) * 0.35 * depth,
+        depth,
+        radius: 1.2 + depth * 3.4,
+      };
+    });
+  }
+
+  function limitVelocity(node, limit){
+    const mag = Math.hypot(node.vx, node.vy);
+    if(mag > limit){
+      const scale = limit / (mag || 1);
+      node.vx *= scale;
+      node.vy *= scale;
+    }
+  }
+
+  function update(){
+    const now = performance.now();
+    if(pointer.active && now - pointer.last > 1200){
+      pointer.active = false;
+    }
+
+    ctx.clearRect(0, 0, width, height);
+
+    const maxDist = Math.min(width, height) * 0.35;
+    const influence = Math.min(width, height) * 0.45;
+
+    for(const node of nodes){
+      let ax = (Math.random() - 0.5) * 0.02;
+      let ay = (Math.random() - 0.5) * 0.02;
+
+      if(pointer.active){
+        const dx = pointer.x - node.x;
+        const dy = pointer.y - node.y;
+        const dist = Math.hypot(dx, dy) + 0.0001;
+        if(dist < influence){
+          const force = (1 - dist / influence) * 0.18 * node.depth;
+          ax += (dx / dist) * force;
+          ay += (dy / dist) * force;
+        }
+      }
+
+      node.vx = (node.vx + ax) * 0.98;
+      node.vy = (node.vy + ay) * 0.98;
+      limitVelocity(node, 0.45 + node.depth * 0.9);
+
+      node.x += node.vx;
+      node.y += node.vy;
+
+      if(node.x < -60) node.x = width + 60;
+      if(node.x > width + 60) node.x = -60;
+      if(node.y < -60) node.y = height + 60;
+      if(node.y > height + 60) node.y = -60;
+    }
+
+    drawConnections(maxDist);
+    drawNodes();
+
+    requestAnimationFrame(update);
+  }
+
+  function drawConnections(maxDist){
+    for(let i = 0; i < nodes.length; i++){
+      const a = nodes[i];
+      for(let j = i + 1; j < nodes.length; j++){
+        const b = nodes[j];
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const dist = Math.hypot(dx, dy);
+        if(dist > maxDist) continue;
+        const depthMix = (a.depth + b.depth) * 0.5;
+        const opacity = Math.max(0, 0.35 * (1 - dist / maxDist) * depthMix);
+        if(opacity < 0.02) continue;
+        ctx.strokeStyle = `rgba(148, 197, 255, ${opacity})`;
+        ctx.lineWidth = 0.6 + depthMix * 0.6;
+        ctx.beginPath();
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+        ctx.stroke();
+      }
+    }
+  }
+
+  function drawNodes(){
+    for(const node of nodes){
+      const gradient = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, node.radius * 1.6);
+      const highlight = Math.min(1, 0.4 + node.depth * 0.5);
+      gradient.addColorStop(0, `rgba(226, 242, 255, ${highlight})`);
+      gradient.addColorStop(0.4, `rgba(168, 216, 255, ${highlight * 0.7})`);
+      gradient.addColorStop(1, 'rgba(28, 78, 118, 0)');
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  resize();
+  window.addEventListener('resize', resize);
+  requestAnimationFrame(update);
+})();

--- a/styles.css
+++ b/styles.css
@@ -123,17 +123,32 @@ body{
 .header{
   position: relative;
   text-align: center;
-  background-image: url('./media/background.gif');
-  background-size: cover; background-position: center;
+  background:
+    radial-gradient(120% 140% at 80% 0%, rgba(34, 211, 238, 0.22), transparent 60%),
+    radial-gradient(140% 160% at 10% 10%, rgba(139, 92, 246, 0.2), transparent 55%),
+    linear-gradient(160deg, var(--bg-1), var(--bg-2));
   color: white;
-  padding: 60px 20px 120px;
+  padding: 80px 20px 140px;
   isolation: isolate;
+  overflow: hidden;
 }
 .header::after{
   content:""; position: absolute; inset: 0; z-index: 0;
   background: linear-gradient(180deg, rgba(0,0,0,0.35), rgba(0,0,0,0.55));
 }
 .header > *{ position: relative; z-index: 1; }
+.hero-network{
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+.hero-network canvas{
+  width: 100%;
+  height: 100%;
+  display: block;
+  filter: saturate(115%) contrast(105%);
+}
 .header h1{ margin: 0 0 6px 0; font-size: 42px; }
 .header p{ margin: 0 0 14px 0; font-size: 16px; color: #f0f3ff; opacity: 0.9; }
 


### PR DESCRIPTION
## Summary
- replace the hero background GIF with a canvas-based node network container
- restyle the header with gradients sized for the interactive backdrop
- add an interactive, pointer-reactive swarm animation that respects reduced-motion preferences

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87fd776d0832caa5f261880fab7e2