### PR TITLE
Refine hero layout and add meeting CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,13 @@
       <a href="blog_pool.html" data-icon="menu">Haptics Pool</a>
       <a href="cts_precision_pinch_blog" data-icon="arrow">Carpal Tunnel</a>
       <a href="index.html#contact" data-icon="arrow">Contact</a>
+      <a
+        href="https://calendar.google.com/calendar/u/0/r/week"
+        class="meeting-cta"
+        data-icon="calendar"
+        target="_blank"
+        rel="noopener noreferrer"
+      >Book a Meeting</a>
     </nav>
     <div class="small">© 2025</div>
   </aside>
@@ -35,6 +42,9 @@
 
     <!-- Hero header (kept; only visual restyle) -->
     <header class="header">
+      <div class="hero-network" aria-hidden="true">
+        <canvas id="heroNetworkCanvas"></canvas>
+      </div>
       <div class="profile-frame">
         <img src="./media/profilepic.jpeg" alt="Profile Picture">
       </div>

--- a/media/icons/icon-calendar.svg
+++ b/media/icons/icon-calendar.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="5" width="18" height="16" rx="3" stroke="#0B1022" stroke-width="1.6"/>
+  <path d="M3 9H21" stroke="#0B1022" stroke-width="1.6" stroke-linecap="round"/>
+  <path d="M8 3V7" stroke="#0B1022" stroke-width="1.6" stroke-linecap="round"/>
+  <path d="M16 3V7" stroke="#0B1022" stroke-width="1.6" stroke-linecap="round"/>
+  <rect x="9" y="12" width="4" height="4" rx="1" fill="#0B1022"/>
+</svg>

--- a/scripts.js
+++ b/scripts.js
@@ -82,3 +82,158 @@
   track.addEventListener('mouseleave', start);
   document.addEventListener('visibilitychange', ()=> document.hidden ? stop() : start());
 })();
+
+/* Hero network animation */
+(function(){
+  const canvas = document.getElementById('heroNetworkCanvas');
+  const header = document.querySelector('.header');
+  if(!canvas || !header) return;
+  if(window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  const ctx = canvas.getContext('2d');
+  let width = 0;
+  let height = 0;
+  let dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let nodes = [];
+
+  const pointer = { x: 0, y: 0, active: false, last: 0 };
+
+  function updatePointer(evt){
+    const rect = canvas.getBoundingClientRect();
+    pointer.x = (evt.clientX || (evt.touches && evt.touches[0]?.clientX) || 0) - rect.left;
+    pointer.y = (evt.clientY || (evt.touches && evt.touches[0]?.clientY) || 0) - rect.top;
+    pointer.active = true;
+    pointer.last = performance.now();
+  }
+
+  function deactivatePointer(){
+    pointer.active = false;
+  }
+
+  header.addEventListener('pointermove', updatePointer, { passive: true });
+  header.addEventListener('pointerdown', updatePointer, { passive: true });
+  header.addEventListener('pointerleave', deactivatePointer);
+  header.addEventListener('touchmove', updatePointer, { passive: true });
+  header.addEventListener('touchend', deactivatePointer);
+
+  function resize(){
+    width = canvas.clientWidth;
+    height = canvas.clientHeight;
+    dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = Math.max(1, Math.floor(width * dpr));
+    canvas.height = Math.max(1, Math.floor(height * dpr));
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    buildNodes();
+  }
+
+  function buildNodes(){
+    const area = width * height;
+    const density = 0.00012;
+    const targetCount = Math.max(60, Math.min(180, Math.floor(area * density)));
+    nodes = new Array(targetCount).fill(null).map(()=>{
+      const depth = 0.3 + Math.random() * 0.7;
+      return {
+        x: Math.random() * width,
+        y: Math.random() * height,
+        vx: (Math.random() - 0.5) * 0.35 * depth,
+        vy: (Math.random() - 0.5) * 0.35 * depth,
+        depth,
+        radius: 1.2 + depth * 3.4,
+      };
+    });
+  }
+
+  function limitVelocity(node, limit){
+    const mag = Math.hypot(node.vx, node.vy);
+    if(mag > limit){
+      const scale = limit / (mag || 1);
+      node.vx *= scale;
+      node.vy *= scale;
+    }
+  }
+
+  function update(){
+    const now = performance.now();
+    if(pointer.active && now - pointer.last > 1200){
+      pointer.active = false;
+    }
+
+    ctx.clearRect(0, 0, width, height);
+
+    const maxDist = Math.min(width, height) * 0.35;
+    const influence = Math.min(width, height) * 0.45;
+
+    for(const node of nodes){
+      let ax = (Math.random() - 0.5) * 0.02;
+      let ay = (Math.random() - 0.5) * 0.02;
+
+      if(pointer.active){
+        const dx = pointer.x - node.x;
+        const dy = pointer.y - node.y;
+        const dist = Math.hypot(dx, dy) + 0.0001;
+        if(dist < influence){
+          const force = (1 - dist / influence) * 0.18 * node.depth;
+          ax += (dx / dist) * force;
+          ay += (dy / dist) * force;
+        }
+      }
+
+      node.vx = (node.vx + ax) * 0.98;
+      node.vy = (node.vy + ay) * 0.98;
+      limitVelocity(node, 0.45 + node.depth * 0.9);
+
+      node.x += node.vx;
+      node.y += node.vy;
+
+      if(node.x < -60) node.x = width + 60;
+      if(node.x > width + 60) node.x = -60;
+      if(node.y < -60) node.y = height + 60;
+      if(node.y > height + 60) node.y = -60;
+    }
+
+    drawConnections(maxDist);
+    drawNodes();
+
+    requestAnimationFrame(update);
+  }
+
+  function drawConnections(maxDist){
+    for(let i = 0; i < nodes.length; i++){
+      const a = nodes[i];
+      for(let j = i + 1; j < nodes.length; j++){
+        const b = nodes[j];
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const dist = Math.hypot(dx, dy);
+        if(dist > maxDist) continue;
+        const depthMix = (a.depth + b.depth) * 0.5;
+        const opacity = Math.max(0, 0.35 * (1 - dist / maxDist) * depthMix);
+        if(opacity < 0.02) continue;
+        ctx.strokeStyle = `rgba(148, 197, 255, ${opacity})`;
+        ctx.lineWidth = 0.6 + depthMix * 0.6;
+        ctx.beginPath();
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+        ctx.stroke();
+      }
+    }
+  }
+
+  function drawNodes(){
+    for(const node of nodes){
+      const gradient = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, node.radius * 1.6);
+      const highlight = Math.min(1, 0.4 + node.depth * 0.5);
+      gradient.addColorStop(0, `rgba(226, 242, 255, ${highlight})`);
+      gradient.addColorStop(0.4, `rgba(168, 216, 255, ${highlight * 0.7})`);
+      gradient.addColorStop(1, 'rgba(28, 78, 118, 0)');
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  resize();
+  window.addEventListener('resize', resize);
+  requestAnimationFrame(update);
+})();

--- a/scripts.js
+++ b/scripts.js
@@ -152,6 +152,8 @@
     }
   }
 
+  let rafId = null;
+
   function update(){
     const now = performance.now();
     if(pointer.active && now - pointer.last > 1200){
@@ -194,7 +196,7 @@
     drawConnections(maxDist);
     drawNodes();
 
-    requestAnimationFrame(update);
+    rafId = requestAnimationFrame(update);
   }
 
   function drawConnections(maxDist){
@@ -233,7 +235,19 @@
     }
   }
 
+  const handleVisibility = ()=>{
+    if(document.hidden){
+      if(rafId){
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+    }else if(!rafId){
+      rafId = requestAnimationFrame(update);
+    }
+  };
+
   resize();
   window.addEventListener('resize', resize);
-  requestAnimationFrame(update);
+  document.addEventListener('visibilitychange', handleVisibility);
+  handleVisibility();
 })();

--- a/styles.css
+++ b/styles.css
@@ -143,7 +143,7 @@ body{
     radial-gradient(140% 160% at 10% 10%, rgba(139, 92, 246, 0.2), transparent 55%),
     linear-gradient(160deg, var(--bg-1), var(--bg-2));
   color: white;
-  padding: 80px 20px 140px;
+  padding: 88px 20px 190px;
   isolation: isolate;
   overflow: visible;
 }
@@ -169,15 +169,23 @@ body{
 
 .profile-frame{
   position: absolute;
-  bottom: -75px;
-  left: 100px;
-  width: 150px; height: 150px;
+  bottom: -95px;
+  left: clamp(32px, 12vw, 160px);
+  width: 176px;
+  height: 176px;
   border-radius: 50%;
   overflow: hidden;
   border: 4px solid white;
   background: #fff;
+  box-shadow: 0 18px 38px rgba(8, 20, 46, 0.35);
 }
-.profile-frame img{ width: 100%; height: 100%; object-fit: cover; }
+.profile-frame img{
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 45%;
+  display: block;
+}
 
 /* ---- Intro text (merged About + original intro-text) -------------------- */
 .intro-wrap{
@@ -304,23 +312,15 @@ body{
   .intro-wrap{ margin-top: 20px; }
   .column{ width: 100%; float: none; }
   .column-text{ height: auto; }
-  .header{ padding-bottom: 140px; }
-
-    /* 👇 ADD this block anywhere before the closing } of @media */
+  .header{ padding: 72px 16px 120px; }
   .profile-frame{
-    position: static;       /* participate in normal flow */
-    left: auto;
-    bottom: auto;
-    width: 120px;
-    height: 120px;
-    margin: 10px auto 0;    /* center under the title */
+    position: static;
+    width: 130px;
+    height: 130px;
+    margin: 0 auto 24px;
+    box-shadow: 0 12px 28px rgba(8, 20, 46, 0.25);
   }
-  .header{
-    padding-bottom: 48px;   /* less space since avatar is now inline */
-  }
-  .intro-wrap{
-    margin-top: 12px;       /* no overlap with avatar */
-  }
+  .intro-wrap{ margin-top: 0; }
   
 }
 

--- a/styles.css
+++ b/styles.css
@@ -103,10 +103,25 @@ body{
 .side-nav a[data-icon="arc-base"]::before{ background-image: url('media/icons/icon-double-arc.svg'); }
 .side-nav a[data-icon="menu"]::before{ background-image: url('media/icons/icon-s-curve.svg'); }
 .side-nav a[data-icon="arrow"]::before{ background-image: url('media/icons/icon-s-curve.svg'); }
+.side-nav a[data-icon="calendar"]::before{ background-image: url('media/icons/icon-calendar.svg'); }
 .side-nav a:hover{
   background: var(--card);
   border-color: var(--card-bd);
   transform: translateX(2px);
+}
+.side-nav a.meeting-cta{
+  margin-top: 4px;
+  font-weight: 600;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0b1022;
+  border-color: transparent;
+  box-shadow: 0 12px 28px rgba(34, 211, 238, 0.18);
+}
+.side-nav a.meeting-cta:hover{
+  transform: translateY(-2px);
+  background: linear-gradient(135deg, #a855f7, #38e1ff);
+  box-shadow: 0 16px 36px rgba(139, 92, 246, 0.28);
+  border-color: transparent;
 }
 .side-nav .small{
   margin-top: auto;
@@ -123,17 +138,32 @@ body{
 .header{
   position: relative;
   text-align: center;
-  background-image: url('./media/background.gif');
-  background-size: cover; background-position: center;
+  background:
+    radial-gradient(120% 140% at 80% 0%, rgba(34, 211, 238, 0.22), transparent 60%),
+    radial-gradient(140% 160% at 10% 10%, rgba(139, 92, 246, 0.2), transparent 55%),
+    linear-gradient(160deg, var(--bg-1), var(--bg-2));
   color: white;
-  padding: 60px 20px 120px;
+  padding: 80px 20px 140px;
   isolation: isolate;
+  overflow: visible;
 }
 .header::after{
   content:""; position: absolute; inset: 0; z-index: 0;
   background: linear-gradient(180deg, rgba(0,0,0,0.35), rgba(0,0,0,0.55));
 }
 .header > *{ position: relative; z-index: 1; }
+.hero-network{
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+.hero-network canvas{
+  width: 100%;
+  height: 100%;
+  display: block;
+  filter: saturate(115%) contrast(105%);
+}
 .header h1{ margin: 0 0 6px 0; font-size: 42px; }
 .header p{ margin: 0 0 14px 0; font-size: 16px; color: #f0f3ff; opacity: 0.9; }
 
@@ -147,7 +177,7 @@ body{
   border: 4px solid white;
   background: #fff;
 }
-.profile-frame img{ width: 100%; height: 100%; object-fit: contain; }
+.profile-frame img{ width: 100%; height: 100%; object-fit: cover; }
 
 /* ---- Intro text (merged About + original intro-text) -------------------- */
 .intro-wrap{


### PR DESCRIPTION
## Summary
- replace the hero background GIF with a canvas-based node network container
- restyle the header with gradients sized for the interactive backdrop
- add an interactive, pointer-reactive swarm animation that respects reduced-motion preferences
- keep the hero avatar fully visible above the interactive header
- add a sidebar "Book a Meeting" CTA with a dedicated calendar icon linking to Google Calendar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d87fd776d0832caa5f261880fab7e2